### PR TITLE
fix(middleware): handle there being no csp header set

### DIFF
--- a/stl/middleware.py
+++ b/stl/middleware.py
@@ -26,8 +26,11 @@ class SecureHeaders:
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
-        csp = response.headers["Content-Security-Policy"]
+        csp = response.headers.get("Content-Security-Policy")
         secure_headers.set_headers(response)  # type: ignore
-        response["Content-Security-Policy"] = csp
+        if csp:
+            response["Content-Security-Policy"] = csp
+        else:
+            del response["Content-Security-Policy"]
 
         return response


### PR DESCRIPTION
## Summary by Sourcery

Fix handling of the Content-Security-Policy header in middleware to ensure it is only set when present, and add a test to verify the behavior when the header is absent.

Bug Fixes:
- Fix handling of missing Content-Security-Policy header in middleware by checking for its existence before setting or deleting it.

Tests:
- Add test to verify behavior when Content-Security-Policy header is not set.