### PR TITLE
bengosney/issue1229

### DIFF
--- a/stl/middleware.py
+++ b/stl/middleware.py
@@ -31,6 +31,6 @@ class SecureHeaders:
         if csp:
             response["Content-Security-Policy"] = csp
         else:
-            del response["Content-Security-Policy"]
+            response.headers.pop("Content-Security-Policy", None)
 
         return response


### PR DESCRIPTION
- **fix(middleware): handle there being no csp header set**


- **fix(middleware): avoid potential issue with deleting non-existing key**

## Summary by Sourcery

Bug Fixes:
- Fix handling of missing Content-Security-Policy header by using pop method to avoid KeyError.