### PR TITLE
fix(CSP): update CSP rules to include CDN and remove unused

### DIFF
--- a/stl/settings/base.py
+++ b/stl/settings/base.py
@@ -187,11 +187,9 @@ CSP_DEFAULT_SRC = "'self'"
 CSP_SCRIPT_SRC = (
     "'self'",
     "'unsafe-inline'",
-    "https://cdnjs.cloudflare.com",
-    "https://cdn.jsdelivr.net",
-    "https://app.embed.im",
+    CDN_URL,
 )
-CSP_STYLE_SRC = ("'self'", "fonts.googleapis.com", "'unsafe-inline'")
+CSP_STYLE_SRC = ("'self'", "fonts.googleapis.com", "'unsafe-inline'", CDN_URL)
 CSP_FONT_SRC = ("'self'", CDN_URL)
 CSP_IMG_SRC = ("'self'", "data:", CDN_URL)
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Update Content Security Policy (CSP) rules to include a dynamic CDN URL and remove unused entries.