### PR TITLE
bengosney/issue1245

### DIFF
--- a/scss/external/_font.scss
+++ b/scss/external/_font.scss
@@ -15,5 +15,3 @@
     url("https://cdn.stretchtheirlegs.co.uk/fonts/fontdiner-swanky-v8-latin-regular.ttf") format("truetype"),
     url("https://cdn.stretchtheirlegs.co.uk/fonts/fontdiner-swanky-v8-latin-regular.svg#FontdinerSwanky") format("svg");
 }
-
-// @import url("https://fonts.googleapis.com/css2?family=Fontdiner+Swanky&display=swap");

--- a/stl/settings/base.py
+++ b/stl/settings/base.py
@@ -184,12 +184,8 @@ CDN_URL = os.environ.get("CDN_URL", "http://localhost")
 WAGTAILADMIN_BASE_URL = BASE_URL
 
 CSP_DEFAULT_SRC = "'self'"
-CSP_SCRIPT_SRC = (
-    "'self'",
-    "'unsafe-inline'",
-    CDN_URL,
-)
-CSP_STYLE_SRC = ("'self'", "fonts.googleapis.com", "'unsafe-inline'", CDN_URL)
+CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'", CDN_URL)
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", CDN_URL)
 CSP_FONT_SRC = ("'self'", CDN_URL)
 CSP_IMG_SRC = ("'self'", "data:", CDN_URL)
 

--- a/stl/settings/base.py
+++ b/stl/settings/base.py
@@ -179,8 +179,8 @@ WAGTAILSEARCH_BACKENDS = {
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-BASE_URL = "https://www.stretchtheirlegs.co.uk"
-CDN_URL = "https://cdn.stretchtheirlegs.co.uk"
+BASE_URL = os.environ.get("BASE_URL", "http://localhost")
+CDN_URL = os.environ.get("CDN_URL", "http://localhost")
 WAGTAILADMIN_BASE_URL = BASE_URL
 
 CSP_DEFAULT_SRC = "'self'"


### PR DESCRIPTION
- **feat(config): move the url and cdn url to env vars**
  Fixes #1245


- **feat(CSP): remove unused csp rules**

## Summary by Sourcery

Move BASE_URL and CDN_URL to environment variables and clean up unused CSP rules.

New Features:
- Move BASE_URL and CDN_URL to environment variables for configuration flexibility.

Enhancements:
- Remove unused Content Security Policy (CSP) rules to simplify security settings.