### PR TITLE
build: update cog output formatting in configuration files Fixes #1554

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     # [[[cog
     # import cog
     # with open(".python-version") as f:
-    #   cog.out(f"- image: cimg/python:{f.read().strip()}", dedent=False)
+    #   cog.out(f"- image: cimg/python:{f.read().strip()}")
     # ]]]
     - image: cimg/python:3.13
     # [[[end]]] (checksum: 96d6336abf295352f87a27601b1ebe2d)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     # [[[cog
     # import cog
     # with open(".python-version") as f:
-    #   cog.out(f"args: [--py{f.read().strip().replace(".", "")}-plus]", dedent=False)
+    #   cog.out(f"args: [--py{f.read().strip().replace(".", "")}-plus]")
     # ]]]
     args: [--py313-plus]
     # [[[end]]] (checksum: 6cea9636c70796bb80ba2c43f851874c)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ requires-python = ">=3.13"
 
 classifiers = [
   # [[[cog
-  # cog.outl(f"\"Programming Language :: Python :: {version.split('.')[0]} :: Only\",", dedent=False)
-  # cog.outl(f"\"Programming Language :: Python :: {version}\",", dedent=False)
+  # cog.outl(f"\"Programming Language :: Python :: {version.split('.')[0]} :: Only\",")
+  # cog.outl(f"\"Programming Language :: Python :: {version}\",")
   # ]]]
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
## Summary by Sourcery

Updates cog output formatting in configuration files to remove the `dedent=False` argument.