### PR TITLE
build: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "20:00"
-      timezone: GMT
+      time: "16:00"
+      timezone: "Europe/London"
     open-pull-requests-limit: 50
     target-branch: main
     versioning-strategy: increase


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Modify Dependabot schedule to run at 16:00 in the Europe/London timezone instead of the previous GMT time setting