### PR TITLE
fix: revert to GMT

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: daily
       time: "16:00"
-      timezone: "Europe/London"
+      timezone: GMT
     open-pull-requests-limit: 50
     target-branch: main
     versioning-strategy: increase


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Updated Dependabot configuration to use GMT timezone instead of Europe/London