### PR TITLE
fix(Makefile): specify output file for UV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ help: ## Display this help
 
 requirements.%.txt: $(UV_PATH) requirements.txt pyproject.toml
 	@echo "Builing $@"
-	python -m uv pip compile --generate-hashes --extra $* $(filter-out $<,$^) > $@
+	python -m uv pip compile --generate-hashes -o $@ --extra $* $(filter-out $<,$^) > /dev/null
 
 requirements.txt: $(UV_PATH) pyproject.toml
 	@echo "Builing $@"
-	python -m uv pip compile --generate-hashes $(filter-out $<,$^) > $@
+	python -m uv pip compile --generate-hashes -o $@ $(filter-out $<,$^) > /dev/null
 
 .direnv: .envrc
 	python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary by Sourcery

Update Makefile to specify output file for UV pip compilation and redirect stdout

Bug Fixes:
- Fixed UV pip compilation commands to correctly specify output files
- Prevented output from being printed to console during requirements file generation