### PR TITLE
fix(Makefile): suppress output for pip compile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ help: ## Display this help
 	pre-commit autoupdate
 
 requirements.%.txt: $(UV_PATH) requirements.txt pyproject.toml
-	@echo "Builing $@"
+	@echo "Building $@"
 	$(UV_PATH) pip compile --quiet --generate-hashes -o $@ --extra $* $(filter-out $<,$^)
 
 requirements.txt: $(UV_PATH) pyproject.toml
-	@echo "Builing $@"
+	@echo "Building $@"
 	$(UV_PATH) pip compile --quiet --generate-hashes -o $@ $(filter-out $<,$^)
 
 .direnv: .envrc

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ help: ## Display this help
 
 requirements.%.txt: $(UV_PATH) requirements.txt pyproject.toml
 	@echo "Builing $@"
-	python -m uv pip compile --generate-hashes -o $@ --extra $* $(filter-out $<,$^) > /dev/null
+	$(UV_PATH) pip compile --quiet --generate-hashes -o $@ --extra $* $(filter-out $<,$^)
 
 requirements.txt: $(UV_PATH) pyproject.toml
 	@echo "Builing $@"
-	python -m uv pip compile --generate-hashes -o $@ $(filter-out $<,$^) > /dev/null
+	$(UV_PATH) pip compile --quiet --generate-hashes -o $@ $(filter-out $<,$^)
 
 .direnv: .envrc
 	python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary by Sourcery

Improve pip compile command output suppression in Makefile

Bug Fixes:
- Replace generic output redirection with uv pip compile's native quiet flag

Chores:
- Update pip compile commands to use more appropriate output suppression method