### PR TITLE
chore(dependabot): remove dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
----
-version: 2
-updates:
-  - schedule:
-      interval: "daily"
-    target-branch: main


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Deleted the Dependabot configuration file (.github/dependabot.yml)