### PR TITLE
fix(dependabot): clean up dependabot configuration for pip updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,12 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: pip
+    directory: "/"
     schedule:
-      interval: "daily"
-    target-branch: main
-    groups: {}
+      interval: daily
+      time: "13:00"
+    groups:
+      python-packages:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary by Sourcery

Update Dependabot configuration for Python package updates

CI:
- Add specific directory and time for pip package updates
- Configure group for all Python packages

Chores:
- Refine Dependabot configuration for pip package ecosystem