### PR TITLE
fix(workflow): change trigger from scheduled to manual for package updates

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -1,8 +1,6 @@
 name: Update packages
 
-on:
-  schedule:
-    - cron: "0 13 * * *"
+on: workflow_dispatch
 
 jobs:
   uv-example:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify GitHub workflow to run package updates on-demand instead of on a fixed schedule