### PR TITLE
fix(workflow): add --upgrade flag to package update command

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Update packages
         id: update
-        run: uv pip compile --quiet --generate-hashes -o requirements.txt pyproject.toml
+        run: uv pip compile --quiet --generate-hashes --upgrade -o requirements.txt pyproject.toml
       
       - name: Get current date
         id: date


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Added --upgrade flag to uv pip compile command in GitHub workflow to force dependency updates