### PR TITLE
build(workflow): correct auto update commit message

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: Update Dependencies
+          commit-message: "build(deps): auto update dependencies"
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: false
           branch: updates-${{ steps.date.outputs.date }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update auto-update workflow commit message to use conventional "build(deps):" prefix