### PR TITLE
chore(dependabot): update schedule time to 19:30 and remove grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,4 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "13:00"
-    groups:
-      python-packages:
-        patterns:
-          - "*"
+      time: "19:30"

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -2,7 +2,7 @@ name: Update packages
 
 on: 
   schedule:
-    - cron: '0 19 * * *' # Every day at 13:00 UTC
+    - cron: '45 19 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Schedule Dependabot updates to run daily at 19:30 and remove grouping configuration