### PR TITLE
fix: add django.contrib.postgres to installed apps

### DIFF
--- a/stl/settings/base.py
+++ b/stl/settings/base.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.sitemaps",
+    "django.contrib.postgres",
     "robots",
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Enable Django's postgres contrib functionality by registering django.contrib.postgres in INSTALLED_APPS.