### PR TITLE
Improve breadcrumb JSON-LD output

### DIFF
--- a/social/tests.py
+++ b/social/tests.py
@@ -2,6 +2,8 @@ from django.template import Context, Template
 from django.test import TestCase
 from django.test.client import RequestFactory
 
+from wagtail.models import Site
+
 from pages.models import Page
 from social.templatetags.social_tags import get_breadcrumbs, jsonld
 
@@ -37,19 +39,48 @@ class TestSiteMessages(TestCase):
 
     def test_breadcrumbs(self):
         root = Page.add_root(title="root")
+        Site.objects.create(hostname="example.com", root_page=root, is_default_site=True)
         prev = root
         for i in range(5):
             prev = prev.add_child(title=f"level {i}")
 
-        crumbs = get_breadcrumbs(prev.get_ancestors())
+        crumbs = list(get_breadcrumbs(prev.get_ancestors()))
 
         expected = [
-            {"@type": "ListItem", "position": 1, "item": {"@id": "root", "name": "root"}},
-            {"@type": "ListItem", "position": 2, "item": {"@id": "level 0", "name": "level 0"}},
-            {"@type": "ListItem", "position": 3, "item": {"@id": "level 1", "name": "level 1"}},
-            {"@type": "ListItem", "position": 4, "item": {"@id": "level 2", "name": "level 2"}},
-            {"@type": "ListItem", "position": 5, "item": {"@id": "level 3", "name": "level 3"}},
+            {
+                "@type": "ListItem",
+                "position": 1,
+                "name": "root",
+                "item": "http://example.com/",
+            },
+            {
+                "@type": "ListItem",
+                "position": 2,
+                "name": "level 0",
+                "item": "http://example.com/level-0/",
+            },
+            {
+                "@type": "ListItem",
+                "position": 3,
+                "name": "level 1",
+                "item": "http://example.com/level-0/level-1/",
+            },
+            {
+                "@type": "ListItem",
+                "position": 4,
+                "name": "level 2",
+                "item": "http://example.com/level-0/level-1/level-2/",
+            },
+            {
+                "@type": "ListItem",
+                "position": 5,
+                "name": "level 3",
+                "item": "http://example.com/level-0/level-1/level-2/level-3/",
+            },
         ]
+
+        for i, crumb in enumerate(crumbs):
+            self.assertEqual(crumb, expected[i])
 
         self.assertEqual(list(crumbs), expected)
 


### PR DESCRIPTION
## Summary by Sourcery

Update breadcrumb JSON-LD generation to output schema.org-compliant breadcrumb items with full URLs and correct page filtering.

New Features:
- Define a typed BreadcrumbListItem structure for breadcrumb JSON-LD entries.

Bug Fixes:
- Ensure breadcrumb JSON-LD items use full page URLs and titles rather than nested objects, matching schema.org expectations.
- Filter breadcrumb items to only include live pages and valid URLs, and correct the position indexing in the breadcrumb list.
- Fix the breadcrumb JSON-LD test to assert against a realistic site root and URL structure.